### PR TITLE
Fixed empty manual when architecture is not x86-64

### DIFF
--- a/cutterref.py
+++ b/cutterref.py
@@ -57,7 +57,8 @@ class CutterRef():
                 inst = "CMOVcc"
             elif(inst[0:3] == "SET"):
                 inst = "SETcc"
-            return inst
+
+        return inst
 
     def find_manuals(self):
         search_path = os.path.join(self.base_path, "archs", "*.sql")


### PR DESCRIPTION
Hi @yossizap,

Thank you for this plugin!

I was trying it on an arm binary and the manual was empty for all the instructions. I think it's due to a small error in the `clean_instruction` method. It was returning nothing when the architecture is not x86-64.

Here's the implementation in `idaref.py`, which I've reproduced in this patch:
https://github.com/nologic/idaref/blob/7e2a86a/idaref.py#L239-L256